### PR TITLE
Fix labeler path for website

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,6 +13,6 @@ workflow:
 website:
   - src/**/*
   - static/**/*
-  - ./*.js
-  - ./*.json
-  - ./*.ts
+  - '*.js'
+  - '*.json'
+  - '*.ts'


### PR DESCRIPTION
This pull request fixes the path for the `website` labels.
