### PR TITLE
Fixes the labeler action trigger to allow write permission

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,6 @@
 name: "Pull Request Labeler"
 on:
-  pull_request:
+  pull_request_target:
 
 permissions:
   contents: read


### PR DESCRIPTION
This pull request fixes the labeler trigger based on the documentation https://github.com/actions/labeler?tab=readme-ov-file#permissions.
