### PR TITLE
Update FileSystem Homework

### DIFF
--- a/docs/devoir/02.md
+++ b/docs/devoir/02.md
@@ -217,7 +217,7 @@ fn rmdir(&mut self, path: &str) -> Result<(), FileSystemError>;
 Cette fonction supprime le fichier spécifié par le chemin. Le répertoire qui contient le fichier doit disposer des autorisations d'écriture.
 Les erreurs suivantes doivent être gérées par cette fonction :
 1. `DirectoryNotEmpty` si le répertoire n'est pas vide
-2. `InvalidFiletype` si le chemin pointe vers un fichier
+2. `InvalidFiletype` si le chemin pointe vers un répertoire
 3. `PermissionDenied` si le répertoire parent ne dispose pas d'autorisations en écriture
 
 ```rust


### PR DESCRIPTION
Modified the `rm` command to mention that the `InvalidFileType` error should be thrown when the file type is a `Folder` instead of a `File`

### Pull Request Overview

The `rm` command requirements incorrectly stated that the given file should be of type `File` for it to return a `InvalidFileType` error instead of being a `Folder`.

### Testing Strategy

N/A


### TODO or Help Wanted

N/A

### Build

- [ ] Ran `npm build`.

### Author

Signed-off-by: Adrian Popescu <adrian.popescu1005@stud.fils.upb.ro>
